### PR TITLE
fix: terms and services link not working from internal pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -127,7 +127,7 @@ const config = {
             ],
           },
 	        {
-            title: "  Terms and policies",
+            title: "Terms and policies",
             items: [
               {
                 label: "Contributors terms of service",


### PR DESCRIPTION
The link was not working from internal pages