### PR TITLE
fix: edit url points to wing repo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,7 +61,7 @@ const config = {
           routeBasePath: "/", // Serve the docs at the site's root
           breadcrumbs: false,
           includeCurrentVersion: false,
-          editUrl: (params)=>`${winglangRepoUrl}/tree/main/docs/${params.docPath}`,   
+          editUrl: (params) => `${winglangRepoUrl}/tree/main/docs/${params.docPath}`,
         },
         blog: false,
         theme: {


### PR DESCRIPTION
Now the edit url will point to the doc file under winglang/wing repo