### PR TITLE
fix: redirect to intended url after log in

### DIFF
--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -10,13 +10,14 @@ export default function RequireAuth(props: PropsWithChildren) {
     if (isLoading) {
       return;
     }
+
     if (isAuthenticated) {
       return;
     }
+
     localStorage.setItem("intendedURL", `${location.pathname}${location.hash}`);
-    loginWithRedirect({
-      redirectUri: `${location.protocol}//${location.host}/login/callback`,
-    });
+
+    loginWithRedirect();
   }, [isLoading, isAuthenticated, error]);
 
   useEffect(() => {
@@ -34,6 +35,14 @@ export default function RequireAuth(props: PropsWithChildren) {
         email: user.email,
         name: user.name,
       });
+    }
+  }, [user]);
+
+  useEffect(() => {
+    // Since we don't render the docs until auth0 retrieves the user info,
+    // we have to explicitely jump to the DOM contents with `location.assign`.
+    if (location.hash) {
+      location.assign(location.hash);
     }
   }, [user]);
 

--- a/src/pages/login/callback.tsx
+++ b/src/pages/login/callback.tsx
@@ -4,6 +4,7 @@ import Loading from "@theme/Loading";
 
 export default function () {
   const { user } = useAuth0();
+
   useEffect(() => {
     if (!user) {
       return;

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -5,7 +5,7 @@ import RequireAuth from "../components/RequireAuth";
 
 export default function Root({ children }) {
   const { siteConfig } = useDocusaurusContext();
-  const redirectUrl = `${siteConfig.url}${siteConfig.baseUrl}`;
+  const redirectUrl = `${siteConfig.url}${siteConfig.baseUrl}login/callback`;
 
   return (
     <Auth0Provider


### PR DESCRIPTION
Before starting the auth process by redirecting to auth0, we will save the intended URL in local storage.

After a successful log in, auth0 will redirect the user to a new page `/login/callback`, which will redirect the user back to the intended URL.