### PR TITLE
Fix typo, world to Wing, on getting started page.

### DIFF
--- a/versioned_docs/version-latest/02-getting-started/05-console.md
+++ b/versioned_docs/version-latest/02-getting-started/05-console.md
@@ -44,7 +44,7 @@ the function that handles messages).
 ## Sending a message to the queue
 
 In the center you should be able to type in a message and send it to the queue.
-Type `world` and hit **Send Message**.
+Type `Wing` and hit **Send Message**.
 
 ## Viewing the file
 


### PR DESCRIPTION
I'm assuming that the intent was to have the final output be 'Hello, Wing' because brand consistency. Hope this helps.