### PR TITLE
fix: hash jump when localstorage  is cleared

### DIFF
--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -54,7 +54,7 @@ export default function RequireAuth(props: PropsWithChildren) {
     if (location.hash) {
       location.assign(location.hash);
     }
-  }, [user, isLoading]);
+  }, [isAuthenticated, isLoading]);
 
   return (
     <>


### PR DESCRIPTION
Now we jump to the browser hash when the variables that indicate whether the content should be displayed change (which are `isAuthenticated` and `isLoading`).