### PR TITLE
fix: "edit this page" leads to 404

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -187,7 +187,7 @@ const config = {
             items: [
               {
                 label:"GitHub",
-                href: winglangRepoUrl,
+                href: winglangOrgUrl,
               },
               {
                 label: "Slack",


### PR DESCRIPTION
Fix break caused by #179 where the URLs did not contain the repository URL but rather the Org URL.
