### PR TITLE
fix: github link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,8 +167,8 @@ const config = {
             className: "header-slack-link",
           },
           {
-            href: winglangOrgUrl,
-            "aria-label": "GitHub Organization",
+            href: `${winglangOrgUrl}/wing/`,
+            "aria-label": "Winglang Repo",
             label: " ",
             position: "right",
             className: "header-github-link",


### PR DESCRIPTION
# Docs updates should not be submitted in this repository

Our doc site content is being automatically updated from [Wing](https://github.com/winglang/wing) repository docs folder.

Please submit any changes to the docs as a PR [here](https://github.com/winglang/wing/pulls)
