### PR TITLE
fix(docs): pointing edit url for cloud resources to libs/wingsdk/src/cloud

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,7 +92,12 @@ const config = {
         docs: {
           breadcrumbs: true,
           includeCurrentVersion: false,
-          editUrl: (params) => `${winglangOrgUrl}/wing/tree/main/docs/docs/${params.docPath}`,
+          editUrl: (params) => {
+            if (/\d+-standard-library\/\d+-cloud/.test(params.docPath)) {
+              return `${winglangOrgUrl}/wing/tree/main/libs/wingsdk/src/cloud/${params.docPath.split("/").pop()}`
+            }
+            return `${winglangOrgUrl}/wing/tree/main/docs/docs/${params.docPath}`
+          },
         },
         blog: {
           blogTitle: 'What\'s up? The Wing Blog',


### PR DESCRIPTION
Before this PR, edit url for cloud resources pointed to a a file that gets build, after this build it should point to source

for example https://www.winglang.io/docs/standard-library/cloud/api points to https://github.com/winglang/wing/blob/main/docs/docs/04-standard-library/01-cloud/api.md instead of https://github.com/winglang/wing/blob/main/libs/wingsdk/src/cloud/api.md

# Docs updates should not be submitted in this repository

Our doc site content is being automatically updated from [Wing](https://github.com/winglang/wing) repository docs folder.

Please submit any changes to the docs as a PR [here](https://github.com/winglang/wing/pulls)
