### PR TITLE
Fixing extra slash in canonical URL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          DOCUSAURUS_URL: https://www.winglang.io/docs
+          DOCUSAURUS_URL: https://www.winglang.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          DOCUSAURUS_URL: https://www.winglang.io/docs/
+          DOCUSAURUS_URL: https://www.winglang.io/docs


### PR DESCRIPTION
I think my earlier PR #728 introduced this minor issue by having a slash at the end of the build.
![CleanShot 2024-01-04 at 14 09 07@2x png](https://github.com/winglang/docsite/assets/1251094/48d5acf9-d339-4077-ade2-bc7d9c7a4f9b)
