### PR TITLE
chore(docs): now loads the /docs by default

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,0 +1,8 @@
+import { useEffect } from 'react';
+
+// Load the docs by default
+export default function Home() {
+  useEffect(() => {
+    window.location = '/docs';
+  }, [])
+}


### PR DESCRIPTION
Just a quality of life improvement, when starting docs you get an empty 404 pages.

This will now redirect you to the /docs page when you start the site locally.

In production the main website is handled elsewhere so this should not effect anyone.