### PR TITLE
bug(docs): fixed issue with open graph image and blog

### DIFF
--- a/blog/2024-03-13-magazine-008.md
+++ b/blog/2024-03-13-magazine-008.md
@@ -12,7 +12,7 @@ tags:
   - changelog
   - newsletter
 hide_table_of_contents: true
-image: ../img/private-api.png
+image: /img/private-api.png
 ---
 import ReactPlayer from "react-player";
 import console_new_look from "./assets/2024-03-13-magazine-008/console-new-look.mp4";

--- a/blog/2024-04-19-magazine-009.md
+++ b/blog/2024-04-19-magazine-009.md
@@ -12,7 +12,7 @@ tags:
   - changelog
   - newsletter
 hide_table_of_contents: true
-image: "../img/inflight-9-banner.png"
+image: "/img/inflight-9-banner.png"
 ---
 
 > The 9th issue of the Wing Inflight Magazine.

--- a/blog/2024-05-07-in-search-for-winglang-middleware-part-two.md
+++ b/blog/2024-05-07-in-search-for-winglang-middleware-part-two.md
@@ -5,7 +5,7 @@ authors:
   - ashersterkin
 tags: [cloud-oriented, programming, middleware, platforms]
 hide_table_of_contents: true
-image: ../img/ashers-blog-middleware-pt-two.jpg
+image: /img/ashers-blog-middleware-pt-two.jpg
 ---
 
 <div style={{color: "#E2EAEB", fontSize: "2rem" }}>Part Two: Pipeline Formation with Template Method </div>

--- a/blog/2024-05-16-chatgpt-client-with-nextjs-and-wing.md
+++ b/blog/2024-05-16-chatgpt-client-with-nextjs-and-wing.md
@@ -5,7 +5,7 @@ authors:
   - nathantarbert
 tags: [cloud-oriented, programming, winglang, platforms]
 hide_table_of_contents: true
-image: ../img/chatgpt-client-cover-art.jpg
+image: /img/chatgpt-client-cover-art.jpg
 ---
 
 ## TL;DR

--- a/blog/2024-05-20-managing-winglang-libraries-with-aws-code-artifact.md
+++ b/blog/2024-05-20-managing-winglang-libraries-with-aws-code-artifact.md
@@ -4,7 +4,7 @@ description: Managing Winglang Libraries with AWS CodeArtifact
 authors:
   - ashersterkin
 tags: [cloud-oriented, programming, middleware, platforms]
-image: ../img/asher-code-artifacts.jpg
+image: /img/asher-code-artifacts.jpg
 hide_table_of_contents: true
 ---
 

--- a/blog/2024-05-29-qa-bot-for-your-docs-with-langchain.md
+++ b/blog/2024-05-29-qa-bot-for-your-docs-with-langchain.md
@@ -5,7 +5,7 @@ authors:
   - nathantarbert
 tags: [cloud-oriented, programming, winglang, platforms]
 hide_table_of_contents: true
-image: ../img/qa-bot-cover-art.png
+image: /img/qa-bot-cover-art.png
 ---
 
 

--- a/blog/2024-08-29-updated-roadmap.md
+++ b/blog/2024-08-29-updated-roadmap.md
@@ -10,7 +10,7 @@ tags:
   - winglang
   - roadmap
 hide_table_of_contents: true
-image: ../img/roadmap-1.0-cover-art.png
+image: /img/roadmap-1.0-cover-art.png
 ---
 
 Hello Wingnuts!

--- a/blog/2024-2-14-five-ways-to-skin-a-lambda-function.md
+++ b/blog/2024-2-14-five-ways-to-skin-a-lambda-function.md
@@ -5,7 +5,7 @@ authors:
   - nathantarbert
 tags: [cloud-oriented, programming, winglang, platforms]
 hide_table_of_contents: true
-image: ../img/5-cloud-functions.png
+image: /img/5-cloud-functions.png
 ---
 
 ![Cover Art](../static/img/5-cloud-functions.png)

--- a/blog/2024-6-12-ported-to-cloud.md
+++ b/blog/2024-6-12-ported-to-cloud.md
@@ -4,7 +4,7 @@ description: Ported to Cloud with Winglang (Part One)
 authors:
   - ashersterkin
 tags: [cloud-oriented, programming, middleware, platforms]
-image: ../img/ported_to_cloud_cover_art.png
+image: /img/ported_to_cloud_cover_art.png
 hide_table_of_contents: true
 ---
 


### PR DESCRIPTION
Fixing issues with open graph images on the website. The URL is rendered as https://www.winglang.io/../img/roadmap-1.0-cover-art.png, this removes the `../`